### PR TITLE
Feature: command executor helper implementation

### DIFF
--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -130,6 +130,10 @@ Essential administration commands.
 - `/playerinfo <player>` - View player details
 - `/players` - List online players
 
+### Auto-Stop System (`auto-stop.js`)
+Automatically stops the server every hour, before activating this script, please add a bash script to auto-start the server and uncomment lines between 10 and 22.
+
+
 ---
 
 ## Configuration

--- a/src/main/java/com/hosttale/simplescripting/managers/ModsDirectoryManager.java
+++ b/src/main/java/com/hosttale/simplescripting/managers/ModsDirectoryManager.java
@@ -127,7 +127,8 @@ public class ModsDirectoryManager {
             "back.js",
             "rtp.js",
             "ranks.js",
-            "admin.js"
+            "admin.js",
+            "auto-stop.js",
         };
         
         // Copy lib files

--- a/src/main/java/com/hosttale/simplescripting/script/JavaScriptContextBuilder.java
+++ b/src/main/java/com/hosttale/simplescripting/script/JavaScriptContextBuilder.java
@@ -27,7 +27,7 @@ public class JavaScriptContextBuilder {
     private final JavaPlugin plugin;
     private final HytaleLogger logger;
     private final ScriptRegistry scriptRegistry;
-    
+
     // Shared instances for hot reload support
     private CommandManager commandManager;
     private EventManager eventManager;
@@ -50,12 +50,12 @@ public class JavaScriptContextBuilder {
 
         // Create Logger instance
         loggerInstance = new Logger(logger);
-        
+
         // Create core API instances
         commandManager = new CommandManager((SimpleScriptingPlugin) plugin, scope, loggerInstance, scriptRegistry);
         eventManager = new EventManager((SimpleScriptingPlugin) plugin, scope, loggerInstance);
         scheduler = new Scheduler(scope, loggerInstance);
-        
+
         // Create helper instances
         TeleportHelper teleportHelper = new TeleportHelper(loggerInstance);
         PlayerHelper playerHelper = new PlayerHelper(loggerInstance);
@@ -64,7 +64,8 @@ public class JavaScriptContextBuilder {
         worldHelper.setScope(scope); // Enable JavaScript callback execution
         PermissionHelper permissionHelper = new PermissionHelper(loggerInstance);
         PluginHelper pluginHelper = new PluginHelper((SimpleScriptingPlugin) plugin, loggerInstance);
-        
+        CommandExecutorHelper commandExecutorHelper = new CommandExecutorHelper(loggerInstance);
+
         // Set up script registry with managers for cleanup
         scriptRegistry.setManagers(commandManager, eventManager, scheduler);
 
@@ -75,7 +76,7 @@ public class JavaScriptContextBuilder {
         exposeApi(scope, "Commands", commandManager);
         exposeApi(scope, "MessageHelper", new MessageHelper());
         exposeApi(scope, "DB", new DatabaseHelper());
-        
+
         // Expose new helper APIs
         exposeApi(scope, "Teleport", teleportHelper);
         exposeApi(scope, "Players", playerHelper);
@@ -84,14 +85,15 @@ public class JavaScriptContextBuilder {
         exposeApi(scope, "Permissions", permissionHelper);
         exposeApi(scope, "Events", eventManager);
         exposeApi(scope, "Colors", Colors.COLOR_MAP);
-        
+        exposeApi(scope, "CommandExecutor", commandExecutorHelper);
+
         // Expose utility classes
         exposeApi(scope, "Transform", Transform.class);
         exposeApi(scope, "Vector3d", Vector3d.class);
 
         return scope;
     }
-    
+
     /**
      * Gets the event manager for system registration.
      * @return The EventManager instance
@@ -99,7 +101,7 @@ public class JavaScriptContextBuilder {
     public EventManager getEventManager() {
         return eventManager;
     }
-    
+
     /**
      * Gets the scheduler for shutdown.
      * @return The Scheduler instance
@@ -107,7 +109,7 @@ public class JavaScriptContextBuilder {
     public Scheduler getScheduler() {
         return scheduler;
     }
-    
+
     /**
      * Gets the command manager.
      * @return The CommandManager instance
@@ -115,7 +117,7 @@ public class JavaScriptContextBuilder {
     public CommandManager getCommandManager() {
         return commandManager;
     }
-    
+
     /**
      * Shuts down all managed resources.
      */
@@ -127,7 +129,7 @@ public class JavaScriptContextBuilder {
             eventManager.clear();
         }
     }
-    
+
     /**
      * Gets the mods directory path.
      * @return Path to the mods directory

--- a/src/main/java/com/hosttale/simplescripting/util/CommandExecutorHelper.java
+++ b/src/main/java/com/hosttale/simplescripting/util/CommandExecutorHelper.java
@@ -1,0 +1,38 @@
+package com.hosttale.simplescripting.util;
+
+import javax.annotation.Nonnull;
+
+import com.hypixel.hytale.server.core.command.system.CommandManager;
+import com.hypixel.hytale.server.core.console.ConsoleSender;
+
+/**
+ * Helper class for executing server commands from JavaScript.
+ * Allows scripts to dispatch commands through the server's console sender.
+ */
+public class CommandExecutorHelper {
+    private final Logger logger;
+
+    public CommandExecutorHelper(Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Dispatches a command as the server console.
+     * 
+     * @param command The command to execute (without the leading /)
+     * @return true if the command was dispatched successfully
+     */
+    public boolean executeAsConsole(@Nonnull String command) {
+        try {
+            String cmdString = command.startsWith("/") ? command.substring(1) : command;
+            
+            logger.warning("Dispatching server command: /" + cmdString);
+
+            CommandManager.get().handleCommand(ConsoleSender.INSTANCE, cmdString);
+            return true;
+        } catch (Exception e) {
+            logger.severe("Error executing command '" + command + "': " + e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/resources/samples/auto-stop.js
+++ b/src/main/resources/samples/auto-stop.js
@@ -1,0 +1,23 @@
+/**
+ * Auto-Stop System
+ * Automatically stops server every hour.
+ *
+ */
+
+(function () {
+	"use strict";
+
+	/** 
+     * Before activating this script, please add a bash script to auto-start the server.
+	 * 
+	 * Example:
+ 	Scheduler.runRepeatingMs(
+		function () {
+			CommandExecutor.executeAsConsole("stop");
+		},
+		1000 * 60 * 60,
+	);
+
+	Logger.info("Auto-Stop script loaded.");
+	*/
+})();


### PR DESCRIPTION
Today, we needed to run a console command, but this feature didn’t exist in the plugin, so I wanted to contribute. We’ve implemented it, are actively using it.